### PR TITLE
allow service discovery for coinmarketcap-exporter

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -37,7 +37,7 @@ scrape_configs:
 
     dns_sd_configs:
     - names:
-      - 'tasks.coinmarketcap-exporter'
+      - 'coinmarketcap-exporter'
       type: 'A'
       port: 9101
     


### PR DESCRIPTION
dns name needs to match the service name in docker-compose